### PR TITLE
Always pass save flag depending on option

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -246,11 +246,8 @@ lazyRequire.installSync = function installSync(name, opts, next) {
 	// Install
 	else {
 		// Arguments
-		const args = ['npm', 'install', name]
-		if (opts.save === true) {
-			args.push('--save')
-			opts.save = null // {delete opts.save} is very slow
-		}
+		const args = ['npm', 'install', name, opts.save === true ? '--save' : '--no-save']
+		opts.save = null // {delete opts.save} is very slow
 
 		// Install
 		const spawnResult = safeps.spawnSync(args, opts)


### PR DESCRIPTION
Fixes #48 

This pull request seeks to resolve an issue where the `save` option has no effect if using NPM >=5. See #48 for full debugging details.

With these changes, a `--save` or `--no-save` flag will always be provided to `npm`, depending on the option value. This is intended to work in both NPM >= 5, as well as NPM < 5, by not allowing any default behavior to take effect.